### PR TITLE
Wrap the basic example in an element to fix syntax highlighting

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,11 +27,13 @@
     </p>
     <demo-snippet>
       <template>
-        Lorem ipsum dolor sit amet.
-        <a id="opener" on-contextmenu="_context" href='#'>
-          Consectetur
-        </a>
-        adipiscing elit.
+        <p>
+          Lorem ipsum dolor sit amet.
+          <a id="opener" on-contextmenu="_context" href='#'>
+            Consectetur
+          </a>
+          adipiscing elit.
+        </p>
 
         <vaadin-context-menu target-selector="#opener" id="menu">
           <paper-menu>


### PR DESCRIPTION
This PR fixes the syntax highlighting on the basic example page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/10)
<!-- Reviewable:end -->
