### PR TITLE
Stop Travis build if task is failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
       "Linux/android@5.1"
     ]'
 script:
+  - set -e
   - gulp lint
   - travis_retry wct
   - travis_retry wct --dom=shadow


### PR DESCRIPTION
Stop build if one of tasks (e.g. linter) is failing. No need to wait for other tasks. Report errors ASAP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/48)
<!-- Reviewable:end -->
