### PR TITLE
Add test for .open(e) method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
       "Linux/android@5.1"
     ]'
 script:
-  - set -e
   - gulp lint
   - travis_retry wct
   - travis_retry wct --dom=shadow

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Bower version](https://img.shields.io/bower/v/vaadin-context-menu.svg) 
+![Bower version](https://img.shields.io/bower/v/vaadin-context-menu.svg)
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://beta.webcomponents.org/element/vaadin/vaadin-context-menu)
-[![Build Status](https://travis-ci.org/vaadin/vaadin-context-menu.svg?branch=master)](https://travis-ci.org/vaadin/vaadin-context-menu) 
+[![Build Status](https://travis-ci.org/vaadin/vaadin-context-menu.svg?branch=master)](https://travis-ci.org/vaadin/vaadin-context-menu)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vaadin/vaadin-core-elements?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # &lt;vaadin-context-menu&gt;
@@ -18,7 +18,7 @@
        font-family: sans-serif;
      }
     </style>
-    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
     <link rel="import" href="../paper-menu/paper-menu.html">
     <link rel="import" href="../paper-item/paper-item.html">
     <link rel="import" href="../paper-item/paper-item-body.html">

--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -7,7 +7,7 @@
 
   <title>vaadin-context-menu Basic Examples</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
   <link rel="import" href="../../vaadin-grid/vaadin-grid.html">
   <link rel="import" href="common.html">
 </head>

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
 
   <title>vaadin-context-menu Basic Examples</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
 
   <link rel="import" href="common.html">
 </head>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>vaadin-context-menu</title>
 
-  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
   <link rel="import" href="../polymer/polymer.html">
   <link rel="import" href="../iron-component-page/iron-component-page.html">
 </head>

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
       WCT.loadSuites([
         'context.html',
         'device-detector.html',
+        'integration.html',
         'selection.html',
         'properties.html',
         'overlay.html',

--- a/test/integration.html
+++ b/test/integration.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+    <link rel="import" href="../vaadin-context-menu.html">
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  </head>
+  <body>
+    <dom-module is="context-menu-button">
+      <template>
+        <vaadin-context-menu id="menu"></vaadin-context-menu>
+        <button on-tap="_showMenu" id="button">Show context menu</button>
+      </template>
+      <script>
+        document.addEventListener('WebComponentsReady', function() {
+          Polymer({
+            is: 'context-menu-button',
+            _showMenu: function(e) {
+              this.$.menu.open(e);
+            }
+          });
+        });
+      </script>
+    </dom-module>
+
+    <test-fixture id="default">
+      <template>
+        <context-menu-button></context-menu-button>
+      </template>
+    </test-fixture>
+
+    <script>
+      describe('integration', function() {
+        var contextMenuButton, menu, button;
+
+        beforeEach(function() {
+          contextMenuButton = fixture('default');
+          menu = contextMenuButton.$.menu;
+          button = contextMenuButton.$.button;
+        });
+
+        it('should open context menu on .open(e)', function() {
+          MockInteractions.tap(button);
+          expect(menu.opened).to.eql(true);
+        });
+      });
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
Connected to #42 
Also:
 - Removed `set -e` from Travis build as it prevents `travis_retry` from repeating tasks
 - Use `webcomponents-lite.min.js` instead of `webcomponents-lite.js` for demos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/56)
<!-- Reviewable:end -->
