### PR TITLE
Make context-menu 'modal' by adding vaadin-overlay

### DIFF
--- a/test/integration.html
+++ b/test/integration.html
@@ -48,6 +48,21 @@
           MockInteractions.tap(button);
           expect(menu.opened).to.eql(true);
         });
+
+        it('should place the backdrop above all other document elements', function(done) {
+          MockInteractions.tap(button);
+          menu.async(function() {
+            var buttonRect = button.getBoundingClientRect();
+            MockInteractions.tap(
+              // this should be backdrop, as it placed above the button
+              document.elementFromPoint(buttonRect.left, buttonRect.top)
+            );
+          }, 80);
+          menu.addEventListener('iron-overlay-closed', function() {
+            expect(menu.opened).to.eql(false);
+            done();
+          });
+        });
       });
     </script>
 

--- a/vaadin-context-menu-overlay.html
+++ b/vaadin-context-menu-overlay.html
@@ -79,7 +79,9 @@ This program is available under Apache License Version 2.0, available at https:/
       },
 
       _phoneChanged: function(phone) {
-        this.withBackdrop = phone;
+        if (!phone) {
+          this.backdropElement.style.opacity = 0;
+        }
       },
 
       // monkey patching iron-overlay-behavior to cancel overriding transform styles.

--- a/vaadin-context-menu.html
+++ b/vaadin-context-menu.html
@@ -142,7 +142,8 @@ Custom property | Description | Default
 
     <content></content>
     <vaadin-context-menu-overlay id="overlay" opened="[[opened]]"
-        on-iron-overlay-opened="_onOverlayOpened" on-iron-overlay-closed="_onOverlayClosed">
+        on-iron-overlay-opened="_onOverlayOpened" on-iron-overlay-closed="_onOverlayClosed"
+        with-backdrop>
     </vaadin-context-menu-overlay>
 
   </template>


### PR DESCRIPTION
Fixes #30 

I made another component for this fix: https://github.com/vaadin/vaadin-overlay/pull/1

Please review the PR above before this one. In case that we are fine with `vaadin-overlay` I'll bump its version and change it in `bower.json` of this PR. Currently, it is pointing to the `init` branch, which is a temporary solution for being able to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/62)
<!-- Reviewable:end -->
