### PR TITLE
Prevent contextmenu on backdrop

### DIFF
--- a/test/overlay.html
+++ b/test/overlay.html
@@ -197,6 +197,20 @@
             });
           });
 
+          it('should close on backdrop contextmenu', function(done) {
+            menu.addEventListener('iron-overlay-closed', function() {
+              expect(menu.opened).to.eql(false);
+              done();
+            });
+
+            var e = new CustomEvent('contextmenu', {
+              cancelable: true,
+              bubbles: true
+            });
+            menu.$.overlay.backdropElement.dispatchEvent(e);
+            expect(e.defaultPrevented).to.be.true;
+          });
+
           it('should close on `click`', function() {
             menu.$.overlay.click();
 

--- a/vaadin-context-menu.html
+++ b/vaadin-context-menu.html
@@ -230,6 +230,12 @@ Custom property | Description | Default
         if (child) {
           child.focus();
         }
+
+        // Close context menu on backdrop right-click
+        this.$.overlay.backdropElement.addEventListener('contextmenu', function(e) {
+          this.close();
+          e.preventDefault();
+        }.bind(this), false);
       },
 
       _onOverlayClosed: function() {


### PR DESCRIPTION
Fixes #65 

With this change context-menu will behave in Linux-way: the second right-click will close the context menu triggered by the first right-click.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/66)
<!-- Reviewable:end -->
