### PR TITLE
Fix iOS closing the overlay in first touch.

### DIFF
--- a/test/touch.html
+++ b/test/touch.html
@@ -55,6 +55,7 @@
         }
 
         node.dispatchEvent(event);
+        return event;
       }
 
       function middleOfNode(node) {
@@ -144,10 +145,21 @@
               bubbles: true
             });
 
-            expect(evt.defaultPrevented).to.eql(true);
+            expect(evt.defaultPrevented).to.eql(false);
 
             done();
           }, 1000);
+        });
+
+        it('should stop `touchend` from creating a tap event which cancels the overlay', function(done) {
+          var xy = middleOfNode(target);
+          makeSoloTouchEvent('touchstart', xy, target);
+
+          menu.async(function() {
+            var evt = makeSoloTouchEvent('touchend', xy, target);
+            expect(evt.defaultPrevented).to.eql(true);
+            done();
+          }, 600);
         });
 
         it('should not open when touch moving', function(done) {

--- a/vaadin-contextmenu-event.html
+++ b/vaadin-contextmenu-event.html
@@ -10,10 +10,10 @@ This program is available under Apache License Version 2.0, available at https:/
   (function() {
     Polymer.Gestures.register({
       name: 'vaadin-contextmenu',
-      deps: ['touchstart', 'touchmove', 'touchend', 'tap', 'contextmenu'],
+      deps: ['touchstart', 'touchmove', 'touchend', 'contextmenu'],
       flow: {
         start: ['touchstart', 'contextmenu'],
-        end: ['tap', 'contextmenu']
+        end: ['contextmenu']
       },
 
       emits: ['vaadin-contextmenu'],
@@ -69,9 +69,6 @@ This program is available under Apache License Version 2.0, available at https:/
         if (this.info.touchJob) {
           this.info.touchJob.stop();
         }
-      },
-
-      tap: function(e) {
         if (this.info.fired) {
           e.preventDefault();
           e.stopPropagation();


### PR DESCRIPTION
Regression after iron-overlay-behavior version 1.10.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/75)
<!-- Reviewable:end -->
