### PR TITLE
Prevent tap from closing the overlay on Android device

### DIFF
--- a/test/touch.html
+++ b/test/touch.html
@@ -96,6 +96,12 @@
         });
       });
 
+      it('should prevent tap', function() {
+        expect(Polymer.Gestures.gestures.tap.info.prevent).to.be.false;
+        target.dispatchEvent(new CustomEvent('contextmenu', {bubbles: true}));
+        expect(Polymer.Gestures.gestures.tap.info.prevent).to.be.true;
+      });
+
       if (ios) {
         it('should open on long-touch on ios', function(done) {
           var xy = middleOfNode(target);

--- a/vaadin-contextmenu-event.html
+++ b/vaadin-contextmenu-event.html
@@ -80,6 +80,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (!e.shiftKey) {
           this.info.sourceEvent = e;
           this.fire(e.target, e.clientX, e.clientY);
+          Polymer.Gestures.prevent('tap');
         }
       },
 


### PR DESCRIPTION
Connects to #78

The issue still occurs on Android devices. Fix by preventing the 'tap' gesture on native 'contextmenu' event also (used in Anrdoid implementation of the gesture)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/81)
<!-- Reviewable:end -->
