### PR TITLE
Remove Paper dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,16 +34,12 @@
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
-    "paper-item": "^2.0.0",
-    "paper-listbox": "^2.0.0",
-    "paper-styles": "^2.0.0",
     "test-fixture": "^3.0.0",
     "vaadin-grid": "^5.0.0",
     "vaadin-item": "^2.0.0",
     "vaadin-list-box": "^1.0.0",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
-    "vaadin-demo-helpers": "^1.0.0",
-    "vaadin-tabs": "^2.0.0"
+    "vaadin-demo-helpers": "^1.2.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
     "test-fixture": "^3.0.0",
+    "vaadin-button": "^2.0.0",
     "vaadin-grid": "^5.0.0",
     "vaadin-item": "^2.0.0",
     "vaadin-list-box": "^1.0.0",

--- a/demo/context-menu-advanced-demos.html
+++ b/demo/context-menu-advanced-demos.html
@@ -18,7 +18,7 @@
             </vaadin-list-box>
           </template>
 
-          <button>Show Context Menu</button>
+          <vaadin-button>Show Context Menu</vaadin-button>
         </vaadin-context-menu>
       </template>
     </vaadin-demo-snippet>

--- a/demo/context-menu-basic-demos.html
+++ b/demo/context-menu-basic-demos.html
@@ -152,7 +152,7 @@
           </template>
         </vaadin-context-menu>
 
-        <button id="menuOpener">Toggle Context Menu</button>
+        <vaadin-button id="menuOpener">Toggle Context Menu</vaadin-button>
 
         <script>
           window.addDemoReadyListener('#context-menu-basic-demos-javascript-api', function(document) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,6 +19,7 @@
 
   <link rel="import" href="context-menu-demo.html">
 
+  <link rel="import" href="../../vaadin-button/vaadin-button.html">
   <link rel="import" href="../../vaadin-grid/vaadin-grid.html">
   <link rel="import" href="../vaadin-context-menu.html">
   <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,13 +21,8 @@
 
   <link rel="import" href="../../vaadin-grid/vaadin-grid.html">
   <link rel="import" href="../vaadin-context-menu.html">
-  <link rel="import" href="../../paper-listbox/paper-listbox.html">
-  <link rel="import" href="../../paper-item/paper-item.html">
-  <link rel="import" href="../../paper-item/paper-item-body.html">
   <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
   <link rel="import" href="../../vaadin-item/vaadin-item.html">
-  <link rel="import" href="../../vaadin-tabs/vaadin-tabs.html">
-  <link rel="import" href="../../vaadin-tabs/vaadin-tab.html">
 
   <vaadin-component-demo config-src="demos.json"></vaadin-component-demo>
 </body>

--- a/test/context.html
+++ b/test/context.html
@@ -8,6 +8,8 @@
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="../vaadin-context-menu.html">
+    <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
+    <link rel="import" href="../../vaadin-item/vaadin-item.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
     <script src="common.js"></script>
@@ -36,9 +38,9 @@
       <template>
         <vaadin-context-menu>
           <template>
-            <paper-listbox id="menu">
-              <paper-item>The menu target: [[target.textContent]]</paper-item>
-            </paper-listbox>
+            <vaadin-list-box id="menu">
+              <vaadin-item>The menu target: [[target.textContent]]</vaadin-item>
+            </vaadin-list-box>
           </template>
           <div id="target">
             Foo

--- a/test/selection.html
+++ b/test/selection.html
@@ -6,8 +6,8 @@
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
-    <link rel="import" href="../../paper-listbox/paper-listbox.html">
-    <link rel="import" href="../../paper-item/paper-item.html">
+    <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
+    <link rel="import" href="../../vaadin-item/vaadin-item.html">
     <link rel="import" href="../vaadin-context-menu.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
@@ -18,11 +18,11 @@
       <template>
         <vaadin-context-menu>
           <template>
-            <paper-listbox id="menu">
-              <paper-item>item1</paper-item>
-              <paper-item>item2</paper-item>
-              <paper-item>item3</paper-item>
-            </paper-listbox>
+            <vaadin-list-box id="menu">
+              <vaadin-item>item1</vaadin-item>
+              <vaadin-item>item2</vaadin-item>
+              <vaadin-item>item3</vaadin-item>
+            </vaadin-list-box>
           </template>
         </vaadin-context-menu>
       </template>
@@ -41,7 +41,7 @@
 
           it('should close on item tap', done => {
             listenOnce(menu, 'opened-changed', () => {
-              MockInteractions.tap(menu.$.overlay.root.querySelector('#menu paper-item'));
+              MockInteractions.tap(menu.$.overlay.root.querySelector('#menu vaadin-item'));
               expect(menu.opened).to.eql(false);
               done();
             });
@@ -56,7 +56,7 @@
                   done();
                 });
 
-                MockInteractions.pressEnter(menu.$.overlay.root.querySelector('#menu paper-item'));
+                MockInteractions.pressEnter(menu.$.overlay.root.querySelector('#menu vaadin-item'));
               }, 10);
             });
 

--- a/test/selection.html
+++ b/test/selection.html
@@ -41,9 +41,12 @@
 
           it('should close on item tap', done => {
             listenOnce(menu, 'opened-changed', () => {
-              MockInteractions.tap(menu.$.overlay.root.querySelector('#menu vaadin-item'));
-              expect(menu.opened).to.eql(false);
-              done();
+              const listBox = menu.$.overlay.shadowRoot.querySelector('#menu');
+              Polymer.RenderStatus.afterNextRender(listBox, () => {
+                MockInteractions.tap(listBox.items[0]);
+                expect(menu.opened).to.eql(false);
+                done();
+              });
             });
 
             menu._setOpened(true);
@@ -56,7 +59,8 @@
                   done();
                 });
 
-                MockInteractions.pressEnter(menu.$.overlay.root.querySelector('#menu vaadin-item'));
+                const item = menu.$.overlay.shadowRoot.querySelector('#menu vaadin-item');
+                MockInteractions.pressAndReleaseKeyOn(item, 13, [], 'Enter');
               }, 10);
             });
 
@@ -66,8 +70,8 @@
           it('should focus the child element', done => {
             listenOnce(menu, 'opened-changed', () => {
               Polymer.Async.microTask.run(() => {
-                var child = menu.$.overlay.root.querySelector('#menu');
-                expect(menu.$.overlay.root.activeElement).to.eql(child);
+                const item = menu.$.overlay.shadowRoot.querySelector('#menu vaadin-item');
+                expect(menu.$.overlay.shadowRoot.activeElement).to.eql(item);
                 done();
               });
             });
@@ -78,8 +82,8 @@
           it('should focus the child element on `contextmenu` event', done => {
             listenOnce(menu, 'opened-changed', () => {
               Polymer.Async.microTask.run(() => {
-                var child = menu.$.overlay.root.querySelector('#menu');
-                expect(menu.$.overlay.root.activeElement).to.eql(child);
+                const item = menu.$.overlay.shadowRoot.querySelector('#menu vaadin-item');
+                expect(menu.$.overlay.shadowRoot.activeElement).to.eql(item);
                 done();
               });
             });


### PR DESCRIPTION
We no longer need these after having #125 merged.

Also replaced native `button` with `vaadin-button` in demos for better appearance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/127)
<!-- Reviewable:end -->
