### PR TITLE
Hide selected item checkmark

### DIFF
--- a/theme/lumo/vaadin-context-menu.html
+++ b/theme/lumo/vaadin-context-menu.html
@@ -26,6 +26,11 @@
         --_lumo-item-selected-icon-display: none;
       }
 
+      /* ShadyCSS workaround (to hide the selected item checkmark) */
+      :host vaadin-list-box vaadin-item::before {
+        display: none;
+      }
+
       :host vaadin-list-box vaadin-item {
         padding-left: calc(var(--lumo-space-m) + var(--lumo-border-radius) / 4);
       }


### PR DESCRIPTION
The ShadyCSS workaround in vaadin-list-box theme causes the checkmark to be visible inside context menu in Chrome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/137)
<!-- Reviewable:end -->
