### PR TITLE
Fix `listen-on` API docs example

### DIFF
--- a/src/vaadin-context-menu.html
+++ b/src/vaadin-context-menu.html
@@ -124,7 +124,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * `listenOn` property:
        *
        * ```html
-       * <vaadin-context-menu id="customListener">
+       * <vaadin-context-menu listen-on="customListener">
        *   <template>
        *     <vaadin-list-box>
        *       ...


### PR DESCRIPTION
Not 100% sure of the proposed fix, but I’m pretty sure the attribute is not meant to be `id`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/138)
<!-- Reviewable:end -->
