### PR TITLE
Disable animations in tests

### DIFF
--- a/test/context.html
+++ b/test/context.html
@@ -10,6 +10,7 @@
     <link rel="import" href="../vaadin-context-menu.html">
     <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
     <link rel="import" href="../../vaadin-item/vaadin-item.html">
+    <link rel="import" href="not-animated-styles.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
     <script src="common.js"></script>

--- a/test/integration.html
+++ b/test/integration.html
@@ -8,6 +8,7 @@
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="../vaadin-context-menu.html">
+    <link rel="import" href="not-animated-styles.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
     <script src="common.js"></script>

--- a/test/not-animated-styles.html
+++ b/test/not-animated-styles.html
@@ -1,0 +1,12 @@
+<dom-module id="not-animated-context-menu-overlay" theme-for="vaadin-context-menu-overlay">
+  <template>
+    <style include="lumo-context-menu-overlay">
+      :host([opening]),
+      :host([closing]),
+      :host([opening]) [part="overlay"],
+      :host([closing]) [part="overlay"] {
+        animation: none !important;
+      }
+    </style>
+  </template>
+</dom-module>

--- a/test/overlay.html
+++ b/test/overlay.html
@@ -7,6 +7,7 @@
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="../vaadin-context-menu.html">
+    <link rel="import" href="not-animated-styles.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
     <script src="common.js"></script>

--- a/test/properties.html
+++ b/test/properties.html
@@ -7,6 +7,7 @@
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="../vaadin-context-menu.html">
+    <link rel="import" href="not-animated-styles.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="common.js"></script>
   </head>

--- a/test/selection.html
+++ b/test/selection.html
@@ -9,6 +9,7 @@
     <link rel="import" href="../../vaadin-list-box/vaadin-list-box.html">
     <link rel="import" href="../../vaadin-item/vaadin-item.html">
     <link rel="import" href="../vaadin-context-menu.html">
+    <link rel="import" href="not-animated-styles.html">
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
     <script src="common.js"></script>

--- a/test/touch.html
+++ b/test/touch.html
@@ -10,6 +10,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
   <link rel="import" href="../vaadin-context-menu.html">
+  <link rel="import" href="not-animated-styles.html">
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <script src="common.js"></script>


### PR DESCRIPTION
In the upcoming `vaadin-overlay` release, the animations feature is to be introduced, which in conjunction with the default animation styles in latest Lumo (`lumo-menu-overlay-core`) cause random failures.

Related https://github.com/vaadin/vaadin-combo-box/pull/632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/146)
<!-- Reviewable:end -->
