### PR TITLE
Update vaadin-context-menu-overlay.html

### DIFF
--- a/src/vaadin-context-menu-overlay.html
+++ b/src/vaadin-context-menu-overlay.html
@@ -21,11 +21,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       :host([bottom-aligned]) {
         justify-content: flex-end;
-      }
-
-      [part="content"] {
-        background-color: #fff;
-      }
+      } 
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
This fixes issue [#181 ](https://github.com/vaadin/vaadin-context-menu/issues/181)

The hardcoded white color clashes with the text color on the Lumo Dark Theme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/184)
<!-- Reviewable:end -->
