### PR TITLE
Manual rendering of the content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "polymer": "^2.0.0",
     "iron-media-query": "^2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0-alpha2",
+    "vaadin-overlay": "vaadin/vaadin-overlay#master",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.1",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.1.1"

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "polymer": "^2.0.0",
     "iron-media-query": "^2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
-    "vaadin-overlay": "vaadin/vaadin-overlay#master",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0-alpha3",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.1",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.1.1"

--- a/src/vaadin-context-menu.html
+++ b/src/vaadin-context-menu.html
@@ -406,6 +406,13 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.overlay.opened = opened;
         }
 
+        /**
+         * Manually invoke existing renderer.
+         */
+        render() {
+          this.$.overlay.render();
+        }
+
         _removeNewRendererOrTemplate(template, oldTemplate, renderer, oldRenderer) {
           if (template !== oldTemplate) {
             this._contentTemplate = undefined;

--- a/test/renderer.html
+++ b/test/renderer.html
@@ -119,8 +119,9 @@
 
         it('should be possible to manually invoke renderer', () => {
           fire(target, 'vaadin-contextmenu');
+          expect(menu.renderer).to.be.calledOnce;
           menu.render();
-          expect(menu.renderer.calledTwice).to.be.true;
+          expect(menu.renderer).to.be.calledTwice;
         });
       });
 

--- a/test/renderer.html
+++ b/test/renderer.html
@@ -116,6 +116,12 @@
           }).to.throw(Error);
           expect(menu._contentTemplate).to.be.not.ok;
         });
+
+        it('should be possible to manually invoke renderer', () => {
+          fire(target, 'vaadin-contextmenu');
+          menu.render();
+          expect(menu.renderer.calledTwice).to.be.true;
+        });
       });
 
       describe('with template', () => {


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/409

The behaviour of the renderer in this case is slightly different from other overlay dependent components as `renderer` can be invoked only once `context` is available. It is assigned on `open`, so there is no way to manually invoke `render` before `context-menu` is opened.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/186)
<!-- Reviewable:end -->
