### PR TITLE
Rename polymer template demo id

### DIFF
--- a/demo/context-menu-basic-demos.html
+++ b/demo/context-menu-basic-demos.html
@@ -37,7 +37,7 @@
 
 
     <h3>Defining Content with Polymer Templates</h3>
-    <vaadin-demo-snippet id="context-menu-basic-demos-basic-usage">
+    <vaadin-demo-snippet id="context-menu-basic-demos-polymer-template">
       <template preserve-content>
         <vaadin-context-menu>
           <template>


### PR DESCRIPTION
`#context-menu-basic-demos-basic-usage` is defined twice and https://github.com/vaadin/vaadin-context-menu/blob/master/demo/context-menu-basic-demos.html#L18 might use wrong demo snippet