### PR TITLE
Fix context menu basic example to mention renderer [skip ci]

### DIFF
--- a/demo/context-menu-basic-demos.html
+++ b/demo/context-menu-basic-demos.html
@@ -11,7 +11,7 @@
     <vaadin-demo-snippet id="context-menu-basic-demos-basic-usage">
       <template preserve-content>
         <vaadin-context-menu>
-          <p>This paragraph has the context menu provided in the above template.</p>
+          <p>This paragraph has the context menu provided in the renderer function below.</p>
           <p>Another paragraph with the context menu that can be opened with <b>right click</b> or with <b>long touch.</b></p>
         </vaadin-context-menu>
         <script>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/195)
<!-- Reviewable:end -->
