### PR TITLE
Remove list-box and item imports from Material theme

### DIFF
--- a/theme/material/vaadin-context-menu-styles.html
+++ b/theme/material/vaadin-context-menu-styles.html
@@ -1,7 +1,5 @@
 <link rel="import" href="../../../vaadin-material-styles/font-icons.html">
 <link rel="import" href="../../../vaadin-material-styles/color.html">
-<link rel="import" href="../../../vaadin-item/theme/material/vaadin-item.html">
-<link rel="import" href="../../../vaadin-list-box/theme/material/vaadin-list-box.html">
 <link rel="import" href="../../../vaadin-material-styles/mixins/menu-overlay.html">
 
 <dom-module id="material-context-menu-overlay" theme-for="vaadin-context-menu-overlay">


### PR DESCRIPTION
The `vaadin-context-menu` does not install neither `vaadin-list-box` nor `vaadin-item` dependencies, and the users could technically use `paper-listbox` instead, although we do not promote that in demos anymore. In that case, these imports could cause 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/198)
<!-- Reviewable:end -->
