### PR TITLE
Enable menu close on backdrop click

### DIFF
--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -209,6 +209,7 @@
         });
 
         menu.addEventListener('item-selected', menu.close);
+        menu.$.overlay.$.backdrop.addEventListener('click', () => menu.close());
 
         menu.$.overlay.addEventListener('keydown', e => {
           if (e.keyCode === 37 || e.keyCode === 27) {

--- a/test/items.html
+++ b/test/items.html
@@ -193,6 +193,16 @@
           expect(subMenu.opened).to.be.true;
         });
 
+        it('should not close on parent item click', () => {
+          menuComponents(rootMenu)[0].click();
+          expect(rootMenu.opened).to.be.true;
+        });
+
+        it('shuold close on backdrop click', () => {
+          subMenu.$.overlay.$.backdrop.click();
+          expect(subMenu.opened).to.be.false;
+        });
+
         it('should have be a parent item', () => {
           expect(menuComponents()[0].classList.contains('vaadin-context-menu-parent-item')).to.be.true;
         });


### PR DESCRIPTION
Currently, the (sub) menus don't close on backdrop click (mobile). This PR fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/202)
<!-- Reviewable:end -->
