### PR TITLE
fix: workaround document click event in Firefox

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "polymer": "^2.0.0",
     "iron-media-query": "^2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.3.2",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.9",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.1",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.1.1",

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "iron-test-helpers": "^2.0.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.0",
     "vaadin-grid": "vaadin/vaadin-grid#^5.2.0",
-    "webcomponentsjs": "^1.0.0",
+    "webcomponentsjs": "1.3.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.2.0"
   },

--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -114,12 +114,14 @@
 
     connectedCallback() {
       super.connectedCallback();
-      document.addEventListener('click', this.__itemsOutsideClickListener);
+      // Firefox leaks click to document on contextmenu even if prevented
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=990614
+      document.documentElement.addEventListener('click', this.__itemsOutsideClickListener);
     }
 
     disconnectedCallback() {
       super.disconnectedCallback();
-      document.removeEventListener('click', this.__itemsOutsideClickListener);
+      document.documentElement.removeEventListener('click', this.__itemsOutsideClickListener);
     }
 
     __openSubMenu(subMenu, itemElement) {

--- a/test/items.html
+++ b/test/items.html
@@ -82,14 +82,14 @@
         });
 
         it('should close all menus', () => {
-          fire(document, 'click');
+          fire(document.documentElement, 'click');
           expect(rootMenu.opened).to.be.false;
           expect(subMenu.opened).to.be.false;
         });
 
         it('should remove close listener', () => {
           rootMenu.parentNode.removeChild(rootMenu);
-          fire(document, 'click');
+          fire(document.documentElement, 'click');
           expect(rootMenu.opened).to.be.true;
         });
 


### PR DESCRIPTION
Connected to #214 

This is a fix for the "Nested Menu Items" demo. The basic context-menu will be fixed in overlay PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/215)
<!-- Reviewable:end -->
