### PR TITLE
Improve test coverage for vaadin-contextmenu gesture event

### DIFF
--- a/src/vaadin-contextmenu-event.html
+++ b/src/vaadin-contextmenu-event.html
@@ -38,8 +38,6 @@ This program is available under Apache License Version 2.0, available at https:/
       },
 
       touchstart: function(e) {
-        this._cancelTimer();
-
         this.info.sourceEvent = e;
         this.info.touchStartCoords = {
           x: e.changedTouches[0].clientX,

--- a/test/touch.html
+++ b/test/touch.html
@@ -204,6 +204,18 @@
           target.dispatchEvent(ev);
         });
 
+        it('should forward `preventDefault` to `sourceEvent`', done => {
+          const ev = makeSoloTouchEvent('touchstart', null, target);
+          menu.listenOn.addEventListener('vaadin-contextmenu', e => {
+            e.preventDefault();
+            setTimeout(() => {
+              expect(ev.defaultPrevented).to.be.true;
+              done();
+            });
+          });
+          target.dispatchEvent(ev);
+        });
+
         it('should not preventDefault on touch-end after normal tap', done => {
           makeSoloTouchEvent('touchstart', null, target);
 

--- a/test/touch.html
+++ b/test/touch.html
@@ -68,7 +68,7 @@
         menu.close();
       });
 
-      function makeSoloTouchEvent(type, xy, node) {
+      function makeSoloTouchEvent(type, xy, node, shiftKey = false) {
         xy = xy || middleOfNode(node);
         const touches = makeTouches([xy], node);
         const touchEventInit = {
@@ -86,6 +86,7 @@
           event[property] = touchEventInit[property];
         }
 
+        event.shiftKey = shiftKey;
         node.dispatchEvent(event);
         return event;
       }
@@ -161,6 +162,48 @@
           }, 1000);
         });
 
+        it('should not open when `touchend` was fired too early', done => {
+          const xy = middleOfNode(menu.listenOn);
+          makeSoloTouchEvent('touchstart', xy, target);
+
+          setTimeout(() => {
+            makeSoloTouchEvent('touchend', null, menu.listenOn);
+          }, 499);
+          // Timeout for dispatching `vaadin-contextmenu` is 500
+
+          setTimeout(() => {
+            expect(menu.opened).to.eql(false);
+            done();
+          }, 1000);
+        });
+
+        it('should not open when `touchstart` was dispatch with `shiftKey`', done => {
+          makeSoloTouchEvent('touchstart', null, target, true);
+
+          setTimeout(() => {
+            expect(menu.opened).to.eql(false);
+            done();
+          }, 1000);
+        });
+
+        it('should properly set `sourceEvent` on `contextmenu`', done => {
+          const ev = new CustomEvent('contextmenu', {bubbles: true});
+          menu.listenOn.addEventListener('vaadin-contextmenu', e => {
+            expect(e.detail.sourceEvent).to.eql(ev);
+            done();
+          });
+          target.dispatchEvent(ev);
+        });
+
+        it('should properly set `sourceEvent` on `touchstart`', done => {
+          const ev = makeSoloTouchEvent('touchstart', null, target);
+          menu.listenOn.addEventListener('vaadin-contextmenu', e => {
+            expect(e.detail.sourceEvent).to.eql(ev);
+            done();
+          });
+          target.dispatchEvent(ev);
+        });
+
         it('should not preventDefault on touch-end after normal tap', done => {
           makeSoloTouchEvent('touchstart', null, target);
 
@@ -208,11 +251,11 @@
 
         it('should not open when touch moving', done => {
           const xy = middleOfNode(menu.listenOn);
-          makeSoloTouchEvent('touchstart', xy, menu.listenOn);
+          makeSoloTouchEvent('touchstart', xy, target);
 
           setTimeout(() => {
             xy.x += 16; // threshold is 15px from start
-            makeSoloTouchEvent('touchmove', xy, menu.listenOn);
+            makeSoloTouchEvent('touchmove', xy, target);
           }, 100);
 
           setTimeout(() => {


### PR DESCRIPTION
Fixes #219 
Tests are now covering the major part of the code.
Some `Polymer.Gestures` specific code is not covered (due to the ticket specification) such as `name`, `flow`, `reset` function which is used internally in `gesture` util.
As for the removing `this._cancelTimer();` from `touchstart` it will be removed on `touchend`, so it's not required over there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/221)
<!-- Reviewable:end -->
