### PR TITLE
fix: ensure list-box items CSS specificity in Safari

### DIFF
--- a/theme/lumo/vaadin-context-menu-styles.html
+++ b/theme/lumo/vaadin-context-menu-styles.html
@@ -42,11 +42,6 @@
         --_lumo-list-box-item-selected-icon-display: block;
       }
 
-      :host(.vaadin-menu-list-box) [part="items"] ::slotted(.vaadin-menu-item) {
-        padding-left: calc(var(--lumo-border-radius) / 4);
-        padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
-      }
-
       /* Normal item */
 
       [part="items"] ::slotted(.vaadin-menu-item) {
@@ -58,6 +53,11 @@
         outline: none;
         border-radius: var(--lumo-border-radius);
         padding-left: var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius) / 4));
+        padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
+      }
+
+      :host(.vaadin-menu-list-box) [part="items"] ::slotted(.vaadin-menu-item) {
+        padding-left: calc(var(--lumo-border-radius) / 4);
         padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
       }
 


### PR DESCRIPTION
Fixes #222 

Looks like the `:host(.vaadin-menu-list-box) ` does not affect CSS selector specificity in Safari:

![screen shot 2019-02-21 at 14 47 38](https://user-images.githubusercontent.com/10589913/53170043-b4e2f100-35e7-11e9-9be1-26b9feb40e45.png)

Fixed by moving the corresponding style block below. Could be related to class selectors only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/224)
<!-- Reviewable:end -->
