### PR TITLE
fix: ensure consistent right alignment for nested menus

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,8 @@
   "globals": {
     "Polymer": false,
     "Vaadin": false
+  },
+  "parserOptions": {
+    "ecmaVersion": 2017
   }
 }

--- a/src/vaadin-context-menu-overlay.html
+++ b/src/vaadin-context-menu-overlay.html
@@ -92,7 +92,8 @@ This program is available under Apache License Version 2.0, available at https:/
             xMax: overlayRect.right - contentRect.width,
             yMax,
             left: overlayRect.left,
-            top: overlayRect.top
+            top: overlayRect.top,
+            width: contentRect.width
           };
         }
       }

--- a/src/vaadin-context-menu.html
+++ b/src/vaadin-context-menu.html
@@ -566,7 +566,14 @@ This program is available under Apache License Version 2.0, available at https:/
           // Then set styling attrs for flex-aligning the content appropriatelly.
           const wdthVport = document.documentElement.clientWidth;
           const hghtVport = document.documentElement.clientHeight;
-          if (x < wdthVport / 2 || x < xMax) {
+
+          const parent = overlay.parentOverlay;
+          if (parent && parent.hasAttribute('right-aligned')) {
+            const parentStyle = getComputedStyle(parent);
+            const parentContentRect = parent.$.overlay.getBoundingClientRect();
+            overlay.setAttribute('right-aligned', '');
+            style.right = parseFloat(parentStyle.right) + parentContentRect.width + 'px';
+          } else if (x < wdthVport / 2 || x < xMax) {
             style.left = x + 'px';
           } else {
             style.right = Math.max(0, (wdthVport - x)) + 'px';

--- a/src/vaadin-context-menu.html
+++ b/src/vaadin-context-menu.html
@@ -556,28 +556,47 @@ This program is available under Apache License Version 2.0, available at https:/
           ['right-aligned', 'bottom-aligned'].forEach(attr => overlay.removeAttribute(attr));
 
           // Maximum x and y values are imposed by content size and overlay limits.
-          const {xMax, yMax, left, top} = overlay.getBoundaries();
+          const {xMax, yMax, left, top, width} = overlay.getBoundaries();
           // Reuse saved x and y event values, in order to this method be used async
           // in the `vaadin-overlay-change` which guarantees that overlay is ready
           const x = this.__x || left;
           const y = this.__y || top;
 
           // Select one overlay corner and move to the event x/y position.
-          // Then set styling attrs for flex-aligning the content appropriatelly.
+          // Then set styling attrs for flex-aligning the content appropriately.
           const wdthVport = document.documentElement.clientWidth;
           const hghtVport = document.documentElement.clientHeight;
 
+          // Align to the parent menu overlay, if any.
           const parent = overlay.parentOverlay;
-          if (parent && parent.hasAttribute('right-aligned')) {
-            const parentStyle = getComputedStyle(parent);
+          let alignedToParent = false;
+          if (parent) {
             const parentContentRect = parent.$.overlay.getBoundingClientRect();
-            overlay.setAttribute('right-aligned', '');
-            style.right = parseFloat(parentStyle.right) + parentContentRect.width + 'px';
-          } else if (x < wdthVport / 2 || x < xMax) {
-            style.left = x + 'px';
-          } else {
-            style.right = Math.max(0, (wdthVport - x)) + 'px';
-            overlay.setAttribute('right-aligned', '');
+            if (parent.hasAttribute('right-aligned')) {
+              const parentStyle = getComputedStyle(parent);
+
+              const getPadding = (el, direction) => {
+                return parseFloat(getComputedStyle(el.$.content)['padding' + direction]);
+              };
+              const right = parseFloat(parentStyle.right) + parentContentRect.width;
+              const padding = getPadding(parent, 'Left') + getPadding(overlay, 'Right');
+
+              // Preserve right-aligned, if possible.
+              if ((wdthVport - (right - padding)) > width) {
+                overlay.setAttribute('right-aligned', '');
+                style.right = right - padding + 'px';
+                alignedToParent = true;
+              }
+            }
+          }
+
+          if (!alignedToParent) {
+            if (x < wdthVport / 2 || x < xMax) {
+              style.left = x + 'px';
+            } else {
+              style.right = Math.max(0, (wdthVport - x)) + 'px';
+              overlay.setAttribute('right-aligned', '');
+            }
           }
           if (y < hghtVport / 2 || y < yMax) {
             style.top = y + 'px';

--- a/test/items.html
+++ b/test/items.html
@@ -45,6 +45,10 @@
         return menu.$.overlay.content.querySelector('vaadin-context-menu');
       };
 
+      const nextRender = el => new Promise(resolve => {
+        Polymer.RenderStatus.afterNextRender(el, () => resolve());
+      });
+
       afterEach(() => rootMenu.close());
 
       describe('default', () => {
@@ -132,8 +136,9 @@
             });
           });
 
-          it('should open the subMenu on the left if root menu is right-aligned', done => {
+          it('should open the subMenu on the left if root menu is right-aligned', async() => {
             subMenu.close();
+            await nextRender(subMenu);
             const rootItem = menuComponents()[0];
             const rootItemRect = rootItem.getBoundingClientRect();
             const rootOverlay = rootMenu.$.overlay;
@@ -142,19 +147,17 @@
             rootOverlay.setAttribute('right-aligned', '');
             const padding = parseFloat(getComputedStyle(rootOverlay.$.content).paddingLeft) * 2;
             open(rootItem);
-
-            Polymer.RenderStatus.afterNextRender(subMenu, () => {
-              expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
-              const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
-              const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
-              expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left + padding, 1);
-              done();
-            });
+            await nextRender(subMenu);
+            expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
+            const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
+            const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
+            expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left + padding, 1);
           });
 
-          it('should open the second subMenu on the right again if not enough space', done => {
+          it('should open the second subMenu on the right again if not enough space', async() => {
             let padding;
             subMenu.close();
+            await nextRender(subMenu);
             rootMenu.items[0].children[2].text = 'foo-0-2-longer';
 
             const rootItem = menuComponents()[0];
@@ -164,27 +167,25 @@
             rootOverlay.style.right = rootItemRect.width + 'px';
             rootOverlay.setAttribute('right-aligned', '');
             padding = parseFloat(getComputedStyle(rootOverlay.$.content).paddingLeft) * 2;
+
+            /* first sub-menu right-aligned */
             open(rootItem);
+            await nextRender(subMenu);
+            expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
+            const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
+            const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
+            expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left + padding, 1);
 
-            Polymer.RenderStatus.afterNextRender(subMenu, () => {
-              expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
-              const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
-              const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
-              expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left + padding, 1);
-
-              const nestedItem = menuComponents(subMenu)[2];
-              const nestedItemRect = nestedItem.getBoundingClientRect();
-              padding = parseFloat(getComputedStyle(subMenu.$.overlay.$.content).paddingLeft) * 2;
-              open(nestedItem);
-
-              Polymer.RenderStatus.afterNextRender(subMenu, () => {
-                const subMenu2 = getSubMenu(subMenu);
-                expect(subMenu2.$.overlay.hasAttribute('right-aligned')).to.be.false;
-                const subMenu2Rect = subMenu2.$.overlay.$.content.getBoundingClientRect();
-                expect(subMenu2Rect.left).to.be.closeTo(nestedItemRect.right, 1);
-                done();
-              });
-            });
+            /* second sub-menu left-aligned */
+            const nestedItem = menuComponents(subMenu)[2];
+            const nestedItemRect = nestedItem.getBoundingClientRect();
+            padding = parseFloat(getComputedStyle(subMenu.$.overlay.$.content).paddingLeft) * 2;
+            open(nestedItem);
+            await nextRender(subMenu);
+            const subMenu2 = getSubMenu(subMenu);
+            expect(subMenu2.$.overlay.hasAttribute('right-aligned')).to.be.false;
+            const subMenu2Rect = subMenu2.$.overlay.$.content.getBoundingClientRect();
+            expect(subMenu2Rect.left).to.be.closeTo(nestedItemRect.right, 1);
           });
         }
 

--- a/test/items.html
+++ b/test/items.html
@@ -56,7 +56,10 @@
             {text: 'foo-0', children:
               [
                 {text: 'foo-0-0', checked: true},
-                {text: 'foo-0-1', disabled: true}
+                {text: 'foo-0-1', disabled: true},
+                {text: 'foo-0-2', children: [
+                  {text: 'foo-0-2-0'}
+                ]},
               ]
             },
             {text: 'foo-1'}
@@ -131,18 +134,56 @@
 
           it('should open the subMenu on the left if root menu is right-aligned', done => {
             subMenu.close();
-            const rootItemRect = menuComponents()[0].getBoundingClientRect();
-            rootMenu.$.overlay.style.removeProperty('left');
-            rootMenu.$.overlay.style.right = rootItemRect.width + 'px';
-            rootMenu.$.overlay.setAttribute('right-aligned', '');
-            open(menuComponents()[0]);
+            const rootItem = menuComponents()[0];
+            const rootItemRect = rootItem.getBoundingClientRect();
+            const rootOverlay = rootMenu.$.overlay;
+            rootOverlay.style.removeProperty('left');
+            rootOverlay.style.right = rootItemRect.width + 'px';
+            rootOverlay.setAttribute('right-aligned', '');
+            const padding = parseFloat(getComputedStyle(rootOverlay.$.content).paddingLeft) * 2;
+            open(rootItem);
 
             Polymer.RenderStatus.afterNextRender(subMenu, () => {
               expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
-              const rootMenuRect = rootMenu.$.overlay.$.content.getBoundingClientRect();
+              const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
               const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
-              expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left, 1);
+              expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left + padding, 1);
               done();
+            });
+          });
+
+          it('should open the second subMenu on the right again if not enough space', done => {
+            let padding;
+            subMenu.close();
+            rootMenu.items[0].children[2].text = 'foo-0-2-longer';
+
+            const rootItem = menuComponents()[0];
+            const rootItemRect = rootItem.getBoundingClientRect();
+            const rootOverlay = rootMenu.$.overlay;
+            rootOverlay.style.removeProperty('left');
+            rootOverlay.style.right = rootItemRect.width + 'px';
+            rootOverlay.setAttribute('right-aligned', '');
+            padding = parseFloat(getComputedStyle(rootOverlay.$.content).paddingLeft) * 2;
+            open(rootItem);
+
+            Polymer.RenderStatus.afterNextRender(subMenu, () => {
+              expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
+              const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
+              const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
+              expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left + padding, 1);
+
+              const nestedItem = menuComponents(subMenu)[2];
+              const nestedItemRect = nestedItem.getBoundingClientRect();
+              padding = parseFloat(getComputedStyle(subMenu.$.overlay.$.content).paddingLeft) * 2;
+              open(nestedItem);
+
+              Polymer.RenderStatus.afterNextRender(subMenu, () => {
+                const subMenu2 = getSubMenu(subMenu);
+                expect(subMenu2.$.overlay.hasAttribute('right-aligned')).to.be.false;
+                const subMenu2Rect = subMenu2.$.overlay.$.content.getBoundingClientRect();
+                expect(subMenu2Rect.left).to.be.closeTo(nestedItemRect.right, 1);
+                done();
+              });
             });
           });
         }

--- a/test/items.html
+++ b/test/items.html
@@ -128,6 +128,23 @@
               done();
             });
           });
+
+          it('should open the subMenu on the left if root menu is right-aligned', done => {
+            subMenu.close();
+            const rootItemRect = menuComponents()[0].getBoundingClientRect();
+            rootMenu.$.overlay.style.removeProperty('left');
+            rootMenu.$.overlay.style.right = rootItemRect.width + 'px';
+            rootMenu.$.overlay.setAttribute('right-aligned', '');
+            open(menuComponents()[0]);
+
+            Polymer.RenderStatus.afterNextRender(subMenu, () => {
+              expect(subMenu.$.overlay.hasAttribute('right-aligned')).to.be.true;
+              const rootMenuRect = rootMenu.$.overlay.$.content.getBoundingClientRect();
+              const subMenuRect = subMenu.$.overlay.$.content.getBoundingClientRect();
+              expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left, 1);
+              done();
+            });
+          });
         }
 
         it('should clean up the old content on reopen', () => {


### PR DESCRIPTION
Related to vaadin/vaadin-menu-bar#17

Similar to #223 but now for right-aligned menu, so implementation is different.

### Before

Submenu overlay is left-aligned:

![Screen Shot 2019-03-25 at 10 39 49](https://user-images.githubusercontent.com/10589913/54906001-f9b1be80-4eea-11e9-8b55-a5a770bdf8ec.png)

### After

Submenu overlay is also right aligned and takes parent's content width into account:

![Screen Shot 2019-03-25 at 10 39 29](https://user-images.githubusercontent.com/10589913/54906040-1221d900-4eeb-11e9-9b05-4e7224d300ce.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/228)
<!-- Reviewable:end -->
