### PR TITLE
fix: support extending by not hardcoding tag name

### DIFF
--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -177,7 +177,7 @@
     __itemsRenderer(root, menu, context) {
       this.__initMenu(root, menu);
 
-      const subMenu = root.querySelector('vaadin-context-menu');
+      const subMenu = root.querySelector(this.constructor.is);
       subMenu.closeOn = menu.closeOn;
 
       const listBox = root.querySelector('vaadin-context-menu-list-box');
@@ -235,15 +235,17 @@
 
     __initMenu(root, menu) {
       if (!root.firstElementChild) {
+        const is = this.constructor.is;
         root.innerHTML = `
           <vaadin-context-menu-list-box></vaadin-context-menu-list-box>
-          <vaadin-context-menu hidden></vaadin-context-menu>
+          <${is} hidden></${is}>
         `;
         Polymer.flush();
         const listBox = root.querySelector('vaadin-context-menu-list-box');
         listBox.classList.add('vaadin-menu-list-box');
         requestAnimationFrame(() => listBox.setAttribute('role', 'menu'));
-        const subMenu = root.querySelector('vaadin-context-menu');
+
+        const subMenu = root.querySelector(is);
         subMenu.$.overlay.modeless = true;
         subMenu.openOn = 'opensubmenu';
 


### PR DESCRIPTION
Connected to vaadin/vaadin-menu-bar#73

This is an improvement unlocking the possibility to extend `vaadin-context-menu` in the menu-bar.
One of the use cases for that is a global "contextmenu" listener which is hard to remove otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/245)
<!-- Reviewable:end -->
