### PR TITLE
Switch touchstart to always use mouseover

### DIFF
--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -330,8 +330,7 @@
           }
         };
 
-        const openEvent = this._touch ? 'touchstart' : 'mouseover';
-        menu.$.overlay.addEventListener(openEvent, openSubMenu);
+        menu.$.overlay.addEventListener('mouseover', openSubMenu);
         menu.$.overlay.addEventListener('keydown', e =>
           (e.keyCode === 39 || e.keyCode === 13 || e.keyCode === 32) && openSubMenu(e));
       } else {

--- a/test/items.html
+++ b/test/items.html
@@ -29,8 +29,6 @@
   </test-fixture>
 
   <script>
-    const OPENEVENT = MOBILE ? 'touchstart' : 'mouseover';
-
     describe('items', () => {
       let rootMenu, subMenu, target;
 
@@ -45,7 +43,7 @@
           const overlay = menu.$.overlay;
           overlay.__openingHandler && overlay.__openingHandler();
         }
-        fire(openTarget, OPENEVENT, {});
+        fire(openTarget, 'mouseover', {});
       };
 
       const getSubMenu = (menu = rootMenu) => {
@@ -61,7 +59,7 @@
       describe('default', () => {
         beforeEach(done => {
           rootMenu = fixture('default');
-          rootMenu.openOn = OPENEVENT;
+          rootMenu.openOn = 'mouseover';
           target = rootMenu.firstElementChild;
           rootMenu.items = [
             {text: 'foo-0', children:
@@ -495,7 +493,7 @@
 
         beforeEach(done => {
           rootMenu = fixture('theme');
-          rootMenu.openOn = OPENEVENT;
+          rootMenu.openOn = 'mouseover';
           target = rootMenu.firstElementChild;
           rootMenu.items = [
             {text: 'foo-0', children:

--- a/theme/lumo/vaadin-context-menu-styles.html
+++ b/theme/lumo/vaadin-context-menu-styles.html
@@ -72,14 +72,15 @@
       /* Hovered item */
       /* TODO a workaround until we have "focus-follows-mouse". After that, use the hover style for focus-ring as well */
 
-      [part="items"] ::slotted(.vaadin-menu-item:hover:not([disabled])) {
+      [part="items"] ::slotted(.vaadin-menu-item:hover:not([disabled])),
+      [part="items"] ::slotted(.vaadin-menu-item[expanded]:not([disabled])) {
         background-color: var(--lumo-primary-color-10pct);
       }
 
       /* Focused item */
 
       @media (pointer: coarse) {
-        [part="items"] ::slotted(.vaadin-menu-item:hover:not([disabled])) {
+        [part="items"] ::slotted(.vaadin-menu-item:hover:not([expanded]):not([disabled])) {
           background-color: transparent;
         }
       }


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-context-menu/issues/246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/248)
<!-- Reviewable:end -->
