### PR TITLE
Remove max-height from content as it's present in lumo-styles

### DIFF
--- a/theme/lumo/vaadin-context-menu-styles.html
+++ b/theme/lumo/vaadin-context-menu-styles.html
@@ -18,11 +18,6 @@
         justify-content: flex-end;
       }
 
-      :host([phone]) [part="content"] {
-        /* Ideally should be 100vh but iOS phone addr-bar covers view port */
-        max-height: 80vh;
-      }
-
     /* TODO These style overrides should not be needed.
        We should instead offer a way to have non-selectable items inside the context menu. */
 


### PR DESCRIPTION
Fixes #247
Cannot come up with a proper test for it.
`max-height` is already defined in [`vaadin-lumo-styles`](https://github.com/vaadin/vaadin-lumo-styles/blob/master/mixins/menu-overlay.html#L57-L73) and `content` part is inheriting the `max-height`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu/249)
<!-- Reviewable:end -->
