### PR TITLE
fix: prevent adding styles to arbitrary component in overlay

### DIFF
--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -201,7 +201,7 @@
           component = document.createElement(item.component || 'vaadin-context-menu-item');
         }
 
-        if (component.localName === 'vaadin-context-menu-item') {
+        if (component instanceof Vaadin.ItemElement) {
           component.setAttribute('role', 'menuitem');
           component.classList.add('vaadin-menu-item');
         } else if (component.localName === 'hr') {

--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -203,10 +203,10 @@
 
         if (component.localName === 'vaadin-context-menu-item') {
           component.setAttribute('role', 'menuitem');
+          component.classList.add('vaadin-menu-item');
         } else if (component.localName === 'hr') {
           component.setAttribute('role', 'separator');
         }
-        component.classList.add('vaadin-menu-item');
         this.theme && component.setAttribute('theme', this.theme);
 
         component._item = item;


### PR DESCRIPTION
Only the context-menu items should be highlighted on hover.