### PR TITLE
Close context-menu on disconnect

### DIFF
--- a/src/vaadin-context-menu.html
+++ b/src/vaadin-context-menu.html
@@ -381,6 +381,7 @@ This program is available under Apache License Version 2.0, available at https:/
           super.disconnectedCallback();
 
           window.removeEventListener('scroll', this.__boundOnScroll, true);
+          this.close();
         }
 
         ready() {

--- a/test/context.html
+++ b/test/context.html
@@ -123,6 +123,17 @@
 
           expect(menu.opened).to.be.true;
         });
+
+        it('should be closed after detached', () => {
+          fire(target, 'contextmenu');
+          expect(menu.opened).to.be.true;
+
+          const spy = sinon.spy(menu, 'close');
+
+          menu.parentNode.removeChild(menu);
+          expect(spy).to.be.calledOnce;
+          expect(menu.opened).to.be.false;
+        });
       });
     </script>
 

--- a/test/items.html
+++ b/test/items.html
@@ -101,8 +101,9 @@
 
         it('should remove close listener', () => {
           rootMenu.parentNode.removeChild(rootMenu);
+          const spy = sinon.spy(rootMenu, 'close');
           fire(document.documentElement, 'click');
-          expect(rootMenu.opened).to.be.true;
+          expect(spy).not.to.be.called;
         });
 
         if (!MOBILE) {


### PR DESCRIPTION
Before this change the overlay was left open after detaching the context-menu

Fixes vaadin/vaadin-menu-bar-flow#62