### PR TITLE
Fix: submenu display inside so much on parent menu

### DIFF
--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -170,7 +170,10 @@
         x = itemRect.right;
       } else {
         // Open on the left side
-        x = itemRect.left - itemRect.width;
+        // Get space-left of menu-content with parent-overlay;
+        const spaceLeftSubmenuWithParentOverlay = itemRect.left - parent.getBoundingClientRect().left;
+        // Get x coordinate = the left parent - the width of content of sub-menu - the space-left above
+        x = parent.getBoundingClientRect().left - parent.$.content.clientWidth - spaceLeftSubmenuWithParentOverlay;
         // Make sure there's no gaps between the menus
         content.style.minWidth = parent.$.content.clientWidth + 'px';
       }

--- a/test/items.html
+++ b/test/items.html
@@ -123,7 +123,7 @@
             open(menuComponents()[0]);
             rootItemRect = menuComponents()[0].getBoundingClientRect();
             const subItemRect = menuComponents(subMenu)[0].getBoundingClientRect();
-            expect(subItemRect.right).to.be.below(rootItemRect.left + rootItemRect.width / 2);
+            expect(subItemRect.right).to.be.below(rootItemRect.left);
           });
 
           it('should open the subMenu on the top if root menu is bottom-aligned', done => {


### PR DESCRIPTION
Fixed sub-menu displays (left side of its parent menu)so much inside its parent menu if comparison with sub-menu displays on the right side of its parent menu.

Fixed by getting x coordinate = the left parent - the width of content of sub-menu - the space (left) between menu content and parent-overlay.

Fixes #261

  
