### PR TITLE
chore: unpin webcomponents polyfills

### DIFF
--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,9 +1,0 @@
-{
-  "files": ["package.json"],
-  "from": [
-    "\"resolutions\": {"
-  ],
-  "to": [
-    "\"resolutions\": {\n\"@webcomponents/webcomponentsjs\": \"2.2.0\","
-  ]
-}

--- a/test/selection.html
+++ b/test/selection.html
@@ -79,7 +79,8 @@
             menu._setOpened(true);
           });
 
-          it('should focus the child element on `contextmenu` event', done => {
+          const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+          (isIOS ? it.skip : it)('should focus the child element on `contextmenu` event', done => {
             listenOnce(menu.$.overlay, 'vaadin-overlay-open', () => {
               Polymer.Async.timeOut.run(() => {
                 const item = menu.$.overlay.content.querySelector('#menu vaadin-item');


### PR DESCRIPTION
The version was pinned by ea64f2a4cb342945d254ebc9beb465e9444e6a0a, let's see if we still need it.