### PR TITLE
A fix for https://github.com/vaadin/vaadin-context-menu/issues/280 .

### DIFF
--- a/src/vaadin-contextmenu-items-mixin.html
+++ b/src/vaadin-contextmenu-items-mixin.html
@@ -238,7 +238,12 @@
         this.__toggleMenuComponentAttribute(component, 'menu-item-checked', item.checked);
         this.__toggleMenuComponentAttribute(component, 'disabled', item.disabled);
 
-        component.setAttribute('aria-haspopup', 'false');
+        // The user may have set this already according to what happens when the menu action is executed;
+        // example: may be set to 'dialog' when the action is to show a modal Dialog pop-up window.
+        var ariaUnset = (null === component.getAttribute('aria-haspopup'));
+        if (ariaUnset) {
+          component.setAttribute('aria-haspopup', 'false');
+        }
         component.classList.remove('vaadin-context-menu-parent-item');
         if (item.children && item.children.length) {
           component.classList.add('vaadin-context-menu-parent-item');


### PR DESCRIPTION
This allows a user to set the 'aria-haspopup' attribute for a context menu item without it being overridden by Vaadin's code when there is no child menu item.
