### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -25,7 +25,7 @@ export type ContextMenuRenderer = (
 export type ContextMenuOpenedChanged = CustomEvent<{ value: boolean }>;
 
 /**
- * Fired when the item is selected in the menu using `items` API.
+ * Fired when an item is selected when the context menu is populated using the `items` API.
  */
 export type ContextMenuItemSelected = CustomEvent<{ value: ContextMenuItem }>;
 

--- a/src/vaadin-context-menu.d.ts
+++ b/src/vaadin-context-menu.d.ts
@@ -216,6 +216,9 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  * propagated to the internal `<vaadin-context-menu-overlay>` component.
  * In case of using nested menu items, the `theme` attribute is also propagated
  * to internal `vaadin-context-menu-list-box` and `vaadin-context-menu-item`'s.
+ *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
  */
 declare class ContextMenuElement extends ElementMixin(
   ThemePropertyMixin(ItemsMixin(GestureEventListeners(HTMLElement)))

--- a/src/vaadin-context-menu.js
+++ b/src/vaadin-context-menu.js
@@ -224,6 +224,9 @@ import './vaadin-context-menu-overlay.js';
  * In case of using nested menu items, the `theme` attribute is also propagated
  * to internal `vaadin-context-menu-list-box` and `vaadin-context-menu-item`'s.
  *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemePropertyMixin


### PR DESCRIPTION
1. Added `@fires` annotations to enable VS Code lit-plugin code completion support.
2. Aligned `item-selected` event description.