### PR TITLE
fix: define details type at ContextMenuRendererContext

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -10,7 +10,7 @@ export interface ContextMenuItem {
 
 export interface ContextMenuRendererContext {
   target: HTMLElement;
-  detail?: object;
+  detail?: { sourceEvent: Event };
 }
 
 export type ContextMenuRenderer = (


### PR DESCRIPTION
Add a type definition for the `details` object inside of the `ContextMenuRendererContext` interface.

Fix vaadin/vaadin-context-menu#309