### PR TITLE
chore: disable issues and direct ppl to web-components repo [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Web Components: Bugs and Feature Requests"
+    url: https://github.com/vaadin/web-components/issues/new/choose
+    about: Please report issues related to the TypeScript and HTML API of Vaadin components here.
+  - name: "Flow Components: Bugs and Feature Requests"
+    url: https://github.com/vaadin/flow-components/issues/new/choose
+    about: Please report issues related to the Java API of Vaadin components here.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # &lt;vaadin-context-menu&gt;
 
+> ⚠️ Starting from Vaadin 20, the source code and issues for this component are migrated to the [`vaadin/web-components`](https://github.com/vaadin/web-components/tree/master/packages/vaadin-context-menu) monorepository.
+> This repository contains the source code and releases of `<vaadin-context-menu>` for the Vaadin versions 10 to 19.
+
+[&lt;vaadin-context-menu&gt;](https://vaadin.com/components/vaadin-context-menu) is a Web Component providing a contextual menu, part of the [Vaadin components](https://vaadin.com/components).
+
 [Live Demo ↗](https://vaadin.com/components/vaadin-context-menu/html-examples)
 |
 [API documentation ↗](https://vaadin.com/components/vaadin-context-menu/html-api)
-
-[&lt;vaadin-context-menu&gt;](https://vaadin.com/components/vaadin-context-menu) is a Web Component providing a contextual menu, part of the [Vaadin components](https://vaadin.com/components).
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-context-menu)](https://www.npmjs.com/package/@vaadin/vaadin-context-menu)
 [![Build Status](https://travis-ci.org/vaadin/vaadin-context-menu.svg?branch=master)](https://travis-ci.org/vaadin/vaadin-context-menu)


### PR DESCRIPTION
## Description

All component-related issues (for any version of the component) should be opened either in `the web-components` monorepo (if it's reproducible with TypeScript and HTML, without Vaadin Flow / Java), or in the `flow-components` monorepo (if it's about the Java API). This repository remains open only to be able to release fixes for the versions of this web component used with Vaadin 10, 14 and Vaadin 19 for as long as they are maintained.

In order to make this clear for users, this PR
  - updates the README to make the role of this repo and its relationship with the the `web-components` monorepo very clear
  - disables new issues in this repo: any attempt to create a new issue here would direct users either to the `web-components` or to the `flow-components` monorepo

Related to: https://github.com/vaadin/components-team-tasks/issues/584

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.